### PR TITLE
Patch 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Dependencies
 ------------
 
 * JDK 1.6
-* [Netty 3.4.0.Final](http://netty.io/downloads/)
+* [Netty 3.4](http://netty.io/downloads/)
 
 License
 -------

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty</artifactId>
-      <version>3.4.0.Final</version>
+      <version>3.4.1.Final</version>
       <scope>compile</scope>
     </dependency>
 

--- a/src/main/java/com/biasedbit/http/connection/DefaultHttpConnection.java
+++ b/src/main/java/com/biasedbit/http/connection/DefaultHttpConnection.java
@@ -251,6 +251,7 @@ public class DefaultHttpConnection extends SimpleChannelUpstreamHandler
                 // executes.
             }
         }
+        this.listener.connectionTerminated(this);
     }
 
     @Override

--- a/src/main/java/com/biasedbit/http/future/DefaultHttpRequestFuture.java
+++ b/src/main/java/com/biasedbit/http/future/DefaultHttpRequestFuture.java
@@ -196,6 +196,9 @@ public class DefaultHttpRequestFuture<T>
             this.executionEnd = System.nanoTime();
             this.cause = cause;
             this.done = true;
+            if (cause == HttpRequestFuture.TIMED_OUT) {
+                    this.connection.terminate(cause);
+            }
             if (this.waiters > 0) {
                 this.notifyAll();
             }
@@ -217,6 +220,9 @@ public class DefaultHttpRequestFuture<T>
             this.response = response;
             this.cause = cause;
             this.done = true;
+            if (cause == HttpRequestFuture.TIMED_OUT) {
+                    this.connection.terminate(cause);
+            }
             if (this.waiters > 0) {
                 this.notifyAll();
             }


### PR DESCRIPTION
Added a fix to notify listeners in case of local socket throwing exception. The symptom was a connection pool filled to the MAX with closed sockets after they had thrown an exception.
